### PR TITLE
Add API for cleaning out old documents

### DIFF
--- a/search_service/__init__.py
+++ b/search_service/__init__.py
@@ -11,7 +11,9 @@ from flasgger import Swagger
 
 from search_service.api.table import SearchTableAPI, SearchTableFieldAPI
 from search_service.api.user import SearchUserAPI
-from search_service.api.document import DocumentUserAPI, DocumentTableAPI, DocumentTablesAPI, DocumentUsersAPI
+from search_service.api.document import (DocumentUserAPI, DocumentTableAPI,
+                                         DocumentTablesAPI, DocumentUsersAPI,
+                                         CleanDocumentAPI)
 from search_service.api.healthcheck import healthcheck
 
 # For customized flask use below arguments to override.
@@ -82,6 +84,8 @@ def create_app(*, config_module_class: str) -> Flask:
 
     api.add_resource(DocumentUsersAPI, '/document_user')
     api.add_resource(DocumentUserAPI, '/document_user/<document_id>')
+
+    api.add_resource(CleanDocumentAPI, '/clean_documents')
 
     app.register_blueprint(api_bp)
 

--- a/search_service/api/swagger_doc/document/clean_put.yml
+++ b/search_service/api/swagger_doc/document/clean_put.yml
@@ -1,0 +1,30 @@
+Removes old documents
+Removes old documents in ElasticSearch.
+---
+tags:
+  - 'clean_documents'
+parameters:
+  - name: before_epoch_time
+    in: body
+    schema:
+      type: integer
+    description: Date before which all documents will be deleted. Defaults to two days ago
+    required: false
+  - name: index
+    in: body
+    schema:
+      type: string
+    description: Index from which documents will be deleted. Defaults to table_search_index
+    required: false
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        description: Response from elasticsearch Delete By Query API
+  500:
+    description: Exception encountered while cleaning documents
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'

--- a/search_service/proxy/atlas.py
+++ b/search_service/proxy/atlas.py
@@ -6,7 +6,7 @@ from atlasclient.models import Entity, EntityCollection
 # default search page size
 from atlasclient.utils import parse_table_qualified_name
 from flask import current_app as app
-from typing import Any, List, Dict, Tuple
+from typing import Any, List, Dict, Optional, Tuple
 
 from search_service.models.search_result import SearchResult
 from search_service.models.table import Table
@@ -258,4 +258,7 @@ class AtlasProxy(BaseProxy):
         raise NotImplementedError()
 
     def delete_document(self, *, data: List[str], index: str = '') -> str:
+        raise NotImplementedError()
+
+    def clean_documents(self, *, before: Optional[int], index: str) -> Dict[str, Any]:
         raise NotImplementedError()

--- a/search_service/proxy/base.py
+++ b/search_service/proxy/base.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from search_service.models.search_result import SearchResult
 
@@ -49,4 +49,8 @@ class BaseProxy(metaclass=ABCMeta):
     def delete_document(self, *,
                         data: List[str],
                         index: str = '') -> str:
+        pass
+
+    @abstractmethod
+    def clean_documents(self, *, before: Optional[int], index: str) -> Dict[str, Any]:
         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore = I201
 max-line-length = 120
 
 # modify --cov-fail-under parameter after adding unit tests
-[pytest]
+[tool:pytest]
 addopts = --cov=search_service --cov-fail-under=0 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
 
 [coverage:run]

--- a/tests/unit/api/document/test_clean_document_api.py
+++ b/tests/unit/api/document/test_clean_document_api.py
@@ -1,0 +1,27 @@
+import unittest
+
+from http import HTTPStatus
+from mock import patch, Mock
+
+from search_service.api.document import CleanDocumentAPI
+from search_service import create_app
+
+
+class CleanDocumentAPITest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = create_app(config_module_class='search_service.config.Config')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tear_down(self):
+        self.app_context.pop()
+
+    @patch('search_service.api.document.reqparse.RequestParser')
+    @patch('search_service.api.document.get_proxy_client')
+    def test_put(self, get_proxy, RequestParser) -> None:
+        mock_proxy = get_proxy.return_value = Mock()
+        RequestParser().parse_args.return_value = dict(index='fake_index')
+
+        response = CleanDocumentAPI().put()
+        self.assertEqual(list(response)[1], HTTPStatus.OK)
+        mock_proxy.clean_documents.assert_called_once_with(before=None, index='fake_index')


### PR DESCRIPTION
### Summary of Changes

This PR adds an API for cleaning documents that are old. You can provide an index and date. The endpoint will remove any documents that have not been updated since before the provided date. If no date is provided, the endpoint defaults to two days ago. If no index is provided, it defaults to the table_search_index.

### Tests

I added tests for the API endpoint and for the actual cleaning method

### Documentation

I added Swagger documentation

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
