### PR TITLE
refactor: Update document apis to be compatible with more complicated models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ flask-cors==3.0.8
 itsdangerous==0.24
 Jinja2>=2.10.1
 jsonschema==2.6.0
-marshmallow==2.15.3
+marshmallow==2.20.5
 marshmallow-annotations==2.4.0
 mock==2.0.0
 mypy==0.660

--- a/search_service/api/document.py
+++ b/search_service/api/document.py
@@ -60,7 +60,7 @@ class BaseDocumentsAPI(Resource):
 
         try:
             data = self.schema(many=True, strict=False).loads(args.get('data')).data
-            results = self.proxy.create_document(data=data, index=args.get('index'))
+            results = self.proxy.create_document(data=data, index=args.get('index'), schema=self.schema)
             return results, HTTPStatus.OK
         except RuntimeError as e:
             err_msg = 'Exception encountered while updating documents '
@@ -80,7 +80,7 @@ class BaseDocumentsAPI(Resource):
 
         try:
             data = self.schema(many=True, strict=False).loads(args.get('data')).data
-            results = self.proxy.update_document(data=data, index=args.get('index'))
+            results = self.proxy.update_document(data=data, index=args.get('index'), schema=self.schema)
             return results, HTTPStatus.OK
         except RuntimeError as e:
             err_msg = 'Exception encountered while updating documents '

--- a/search_service/api/table.py
+++ b/search_service/api/table.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Iterable  # noqa: F401
 from flask_restful import Resource, reqparse
 from flasgger import swag_from
 
-from search_service.models.table import SearchTableResultSchema
+from search_service.models.table import SearchTableResultSchema, Table
 from search_service.proxy import get_proxy_client
 
 
@@ -45,7 +45,9 @@ class SearchTableAPI(Resource):
                 index=args.get('index')
             )
 
-            return SearchTableResultSchema().dump(results).data, HTTPStatus.OK
+            data = SearchTableResultSchema().dump(results).data
+            data['results'] = [Table.convert_tags(table) for table in data['results']]
+            return data, HTTPStatus.OK
 
         except RuntimeError:
 
@@ -101,7 +103,9 @@ class SearchTableFilterAPI(Resource):
                 page_index=page_index,
                 index=args['index']
             )
-            return SearchTableResultSchema().dump(results).data, HTTPStatus.OK
+            data = SearchTableResultSchema().dump(results).data
+            data['results'] = [Table.convert_tags(table) for table in data['results']]
+            return data, HTTPStatus.OK
         except RuntimeError:
             err_msg = 'Exception encountered while processing search request'
             return {'message': err_msg}, HTTPStatus.INTERNAL_SERVER_ERROR

--- a/search_service/proxy/atlas.py
+++ b/search_service/proxy/atlas.py
@@ -1,6 +1,6 @@
 import logging
 from re import sub
-from typing import Any, List, Dict, Tuple, Optional
+from typing import Any, List, Dict, Optional, Tuple, Union
 
 from atlasclient.client import Atlas
 from atlasclient.exceptions import BadRequest
@@ -11,8 +11,9 @@ from atlasclient.utils import parse_table_qualified_name
 from search_service.models.dashboard import SearchDashboardResult
 from search_service.models.table import SearchTableResult
 from search_service.models.search_result import SearchResult
-from search_service.models.table import Table
+from search_service.models.table import Table, TableSchema
 from search_service.models.tag import Tag
+from search_service.models.user import User, UserSchema
 from search_service.proxy import BaseProxy
 from search_service.proxy.statsd_utilities import timer_with_counter
 
@@ -269,10 +270,16 @@ class AtlasProxy(BaseProxy):
                                   index: str = '') -> SearchResult:
         pass
 
-    def update_document(self, *, data: List[Dict[str, Any]], index: str = '') -> str:
+    def update_document(self, *,
+                        data: List[Union[Table, User]] = [],
+                        index: str = '',
+                        schema: Union[TableSchema, UserSchema]) -> str:
         raise NotImplementedError()
 
-    def create_document(self, *, data: List[Dict[str, Any]], index: str = '') -> str:
+    def create_document(self, *,
+                        data: List[Union[Table, User]] = [],
+                        index: str = '',
+                        schema: Union[TableSchema, UserSchema]) -> str:
         raise NotImplementedError()
 
     def delete_document(self, *, data: List[str], index: str = '') -> str:

--- a/search_service/proxy/base.py
+++ b/search_service/proxy/base.py
@@ -1,9 +1,11 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, List
+from typing import List, Union
 
 from search_service.models.dashboard import SearchDashboardResult
 from search_service.models.table import SearchTableResult
 from search_service.models.search_result import SearchResult
+from search_service.models.table import Table, TableSchema
+from search_service.models.user import User, UserSchema
 
 
 class BaseProxy(metaclass=ABCMeta):
@@ -28,14 +30,16 @@ class BaseProxy(metaclass=ABCMeta):
 
     @abstractmethod
     def update_document(self, *,
-                        data: List[Dict[str, Any]],
-                        index: str = '') -> str:
+                        data: List[Union[Table, User]] = [],
+                        index: str = '',
+                        schema: Union[TableSchema, UserSchema]) -> str:
         pass
 
     @abstractmethod
     def create_document(self, *,
-                        data: List[Dict[str, Any]],
-                        index: str = '') -> str:
+                        data: List[Union[Table, User]] = [],
+                        index: str = '',
+                        schema: Union[TableSchema, UserSchema]) -> str:
         pass
 
     @abstractmethod

--- a/tests/unit/api/document/test_document_users_api.py
+++ b/tests/unit/api/document/test_document_users_api.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from mock import patch, Mock, MagicMock
 
 from search_service.api.document import DocumentUsersAPI
+from search_service.models.user import UserSchema
 from search_service import create_app
 
 
@@ -24,7 +25,7 @@ class TestDocumentUsersAPI(unittest.TestCase):
 
         response = DocumentUsersAPI().post()
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        mock_proxy.create_document.assert_called_with(data=[], index='fake_index')
+        mock_proxy.create_document.assert_called_with(data=[], index='fake_index', schema=UserSchema)
 
     @patch('search_service.api.document.reqparse.RequestParser')
     @patch('search_service.api.document.get_proxy_client')
@@ -34,7 +35,7 @@ class TestDocumentUsersAPI(unittest.TestCase):
 
         response = DocumentUsersAPI().put()
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        mock_proxy.update_document.assert_called_with(data=[], index='fake_index')
+        mock_proxy.update_document.assert_called_with(data=[], index='fake_index', schema=UserSchema)
 
     def test_should_not_reach_create_with_id(self) -> None:
         response = self.app.test_client().post('/document_user/1')


### PR DESCRIPTION
### Summary of Changes

The logic I originally wrote for the Document APIs simply called `.__dict__` on the data passed in. This worked fine until the search Table model was updated to have a list of Tags rather than a list of strings (`tags=['test1', 'test2']` vs tags=`[{'tag_name': 'test1'}...]`). This causes a serialization error because we should be using the schema to dump the data rather than just calling `__dict__`. 

This gets a bit more complicated because while index map expects a list of tag strings, when we return search results, we expect the tags to be returned as a list of objects. I've taken a stab at fixing this issue in this PR (and cleaned up a few things along the way). 

It would probably be useful in the future for this to be further iterated on, but for now, this PR makes it so that people using Amundsen can use the Document APIs properly.

### Tests

I increased test coverage to 77% from ~75%. I added a test for creating a user document since it looked like we were only testing table document creation. I also updated the create document test to include tags so that this new functionality can be properly tested.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
