### PR TITLE
fix: fix dashboard model errors, change deprecated pytest function

### DIFF
--- a/tests/unit/api/dashboard/fixtures.py
+++ b/tests/unit/api/dashboard/fixtures.py
@@ -18,6 +18,7 @@ def mock_proxy_results() -> Dashboard:
 
 def mock_json_response() -> dict:
     return {
+        "chart_names": [],
         "uri": 'dashboard_uri',
         "cluster": 'gold',
         "group_name": 'mode_dashboard_group',
@@ -32,6 +33,7 @@ def mock_json_response() -> dict:
 
 def default_json_response() -> dict:
     return {
+        "chart_names": [],
         "uri": None,
         "cluster": None,
         "group_name": None,

--- a/tests/unit/api/document/test_document_table_api.py
+++ b/tests/unit/api/document/test_document_table_api.py
@@ -32,4 +32,4 @@ class TestDocumentTableAPI(unittest.TestCase):
     def test_should_not_reach_delete_without_id(self) -> None:
         response = self.app.test_client().delete('/document_table')
 
-        self.assertEquals(response.status_code, 405)
+        self.assertEqual(response.status_code, 405)

--- a/tests/unit/api/document/test_document_tables_api.py
+++ b/tests/unit/api/document/test_document_tables_api.py
@@ -42,9 +42,9 @@ class TestDocumentTablesAPI(unittest.TestCase):
     def test_should_not_reach_create_with_id(self) -> None:
         response = self.app.test_client().post('/document_table/1')
 
-        self.assertEquals(response.status_code, 405)
+        self.assertEqual(response.status_code, 405)
 
     def test_should_not_reach_update_with_id(self) -> None:
         response = self.app.test_client().put('/document_table/1')
 
-        self.assertEquals(response.status_code, 405)
+        self.assertEqual(response.status_code, 405)

--- a/tests/unit/api/document/test_document_user_api.py
+++ b/tests/unit/api/document/test_document_user_api.py
@@ -32,4 +32,4 @@ class TestDocumentUserAPI(unittest.TestCase):
     def test_should_not_reach_delete_without_id(self) -> None:
         response = self.app.test_client().delete('/document_user')
 
-        self.assertEquals(response.status_code, 405)
+        self.assertEqual(response.status_code, 405)

--- a/tests/unit/api/document/test_document_users_api.py
+++ b/tests/unit/api/document/test_document_users_api.py
@@ -42,9 +42,9 @@ class TestDocumentUsersAPI(unittest.TestCase):
     def test_should_not_reach_create_with_id(self) -> None:
         response = self.app.test_client().post('/document_user/1')
 
-        self.assertEquals(response.status_code, 405)
+        self.assertEqual(response.status_code, 405)
 
     def test_should_not_reach_update_with_id(self) -> None:
         response = self.app.test_client().put('/document_user/1')
 
-        self.assertEquals(response.status_code, 405)
+        self.assertEqual(response.status_code, 405)

--- a/tests/unit/proxy/test_atlas.py
+++ b/tests/unit/proxy/test_atlas.py
@@ -242,7 +242,7 @@ class TestAtlasProxy(unittest.TestCase):
 
         with patch.object(self.proxy.atlas.search_basic, 'create', result):
             resp = self.proxy.fetch_table_search_results(query_term="Table")
-            self.assertEquals(resp.total_results, 1)
+            self.assertEqual(resp.total_results, 1)
             self.assertIsInstance(resp.results[0], Table, "Search result received is not of 'Table' type!")
             self.assertDictEqual(vars(resp.results[0]), vars(expected.results[0]),
                                  "Search Result doesn't match with expected result!")

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -238,7 +238,7 @@ class TestElasticsearchProxy(unittest.TestCase):
 
         resp = self.es_proxy.fetch_table_search_results(query_term='test_query_term')
 
-        self.assertEquals(resp.total_results, expected.total_results,
+        self.assertEqual(resp.total_results, expected.total_results,
                           "search result is not of length 1")
         self.assertIsInstance(resp.results[0],
                               Table,
@@ -280,7 +280,7 @@ class TestElasticsearchProxy(unittest.TestCase):
 
         resp = self.es_proxy.fetch_table_search_results(query_term='test_query_term')
 
-        self.assertEquals(resp.total_results, expected.total_results,
+        self.assertEqual(resp.total_results, expected.total_results,
                           "search result is not of length 2")
         for i in range(2):
             self.assertIsInstance(resp.results[i],
@@ -320,15 +320,15 @@ class TestElasticsearchProxy(unittest.TestCase):
         }
         resp = self.es_proxy.fetch_search_results_with_filter(search_request=search_request, query_term='test')
 
-        self.assertEquals(resp.total_results, expected.total_results)
+        self.assertEqual(resp.total_results, expected.total_results)
         self.assertIsInstance(resp.results[0], Table)
         self.assertDictEqual(vars(resp.results[0]), vars(expected.results[0]))
 
     def test_search_table_filter_return_no_results_if_no_search_request(self) -> None:
         resp = self.es_proxy.fetch_search_results_with_filter(search_request=None, query_term='test')
 
-        self.assertEquals(resp.total_results, 0)
-        self.assertEquals(resp.results, [])
+        self.assertEqual(resp.total_results, 0)
+        self.assertEqual(resp.results, [])
 
     def test_search_table_filter_return_no_results_if_dsl_conversion_error(self) -> None:
         search_request = {
@@ -340,14 +340,14 @@ class TestElasticsearchProxy(unittest.TestCase):
             resp = self.es_proxy.fetch_search_results_with_filter(search_request=search_request,
                                                                   query_term='test')
 
-            self.assertEquals(resp.total_results, 0)
-            self.assertEquals(resp.results, [])
+            self.assertEqual(resp.total_results, 0)
+            self.assertEqual(resp.results, [])
 
     def test_get_model_by_index_table(self) -> None:
-        self.assertEquals(self.es_proxy.get_model_by_index(TABLE_INDEX), Table)
+        self.assertEqual(self.es_proxy.get_model_by_index(TABLE_INDEX), Table)
 
     def test_get_model_by_index_user(self) -> None:
-        self.assertEquals(self.es_proxy.get_model_by_index(USER_INDEX), User)
+        self.assertEqual(self.es_proxy.get_model_by_index(USER_INDEX), User)
 
     def test_get_model_by_index_raise_exception(self) -> None:
         self.assertRaises(Exception, self.es_proxy.convert_query_json_to_query_dsl, 'some_fake_index')
@@ -365,14 +365,14 @@ class TestElasticsearchProxy(unittest.TestCase):
                           "AND name.raw:(*amundsen*) " \
                           "AND column_names.raw:(*ds*) " \
                           "AND tags:(test-tag)"
-        self.assertEquals(self.es_proxy.parse_filters(filter_list,
+        self.assertEqual(self.es_proxy.parse_filters(filter_list,
                                                       index=TABLE_INDEX), expected_result)
 
     def test_parse_filters_return_no_results(self) -> None:
         filter_list = {
             'unsupported_category': ['fake']
         }
-        self.assertEquals(self.es_proxy.parse_filters(filter_list,
+        self.assertEqual(self.es_proxy.parse_filters(filter_list,
                                                       index=TABLE_INDEX), '')
 
     def test_validate_wrong_filters_values(self) -> None:
@@ -385,7 +385,7 @@ class TestElasticsearchProxy(unittest.TestCase):
             "query_term": "",
             "page_index": 0
         }
-        self.assertEquals(self.es_proxy.validate_filter_values(search_request), False)
+        self.assertEqual(self.es_proxy.validate_filter_values(search_request), False)
 
     def test_validate_accepted_filters_values(self) -> None:
         search_request = {
@@ -397,7 +397,7 @@ class TestElasticsearchProxy(unittest.TestCase):
             "query_term": "a",
             "page_index": 0
         }
-        self.assertEquals(self.es_proxy.validate_filter_values(search_request), True)
+        self.assertEqual(self.es_proxy.validate_filter_values(search_request), True)
 
     def test_parse_query_term(self) -> None:
         term = 'test'
@@ -405,7 +405,7 @@ class TestElasticsearchProxy(unittest.TestCase):
                           "schema:(test) OR description:(*test*) OR description:(test) OR " \
                           "column_names:(*test*) OR column_names:(test) OR " \
                           "column_descriptions:(*test*) OR column_descriptions:(test))"
-        self.assertEquals(self.es_proxy.parse_query_term(term,
+        self.assertEqual(self.es_proxy.parse_query_term(term,
                                                          index=TABLE_INDEX), expected_result)
 
     def test_convert_query_json_to_query_dsl_term_and_filters(self) -> None:
@@ -427,7 +427,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         ret_result = self.es_proxy.convert_query_json_to_query_dsl(search_request=search_request,
                                                                    query_term=term,
                                                                    index=TABLE_INDEX)
-        self.assertEquals(ret_result, expected_result)
+        self.assertEqual(ret_result, expected_result)
 
     def test_convert_query_json_to_query_dsl_no_term(self) -> None:
         term = ''
@@ -443,7 +443,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         ret_result = self.es_proxy.convert_query_json_to_query_dsl(search_request=search_request,
                                                                    query_term=term,
                                                                    index=TABLE_INDEX)
-        self.assertEquals(ret_result, expected_result)
+        self.assertEqual(ret_result, expected_result)
 
     def test_convert_query_json_to_query_dsl_no_filters(self) -> None:
         term = 'test'
@@ -456,7 +456,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         ret_result = self.es_proxy.convert_query_json_to_query_dsl(search_request=search_request,
                                                                    query_term=term,
                                                                    index=TABLE_INDEX)
-        self.assertEquals(ret_result, expected_result)
+        self.assertEqual(ret_result, expected_result)
 
     def test_convert_query_json_to_query_dsl_raise_exception_no_term_or_filters(self) -> None:
         term = ''
@@ -490,7 +490,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         resp = self.es_proxy.fetch_user_search_results(query_term='test_query_term',
                                                        index='user_search_index')
 
-        self.assertEquals(resp.total_results, expected.total_results,
+        self.assertEqual(resp.total_results, expected.total_results,
                           "search result is not of length 1")
         self.assertIsInstance(resp.results[0],
                               User,
@@ -502,7 +502,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         expected = ''
         result = self.es_proxy.create_document(data=None, index='table_search_index')
         print('result: {}'.format(result))
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     @patch('uuid.uuid4')
     def test_create_document(self, mock_uuid: MagicMock) -> None:
@@ -576,13 +576,13 @@ class TestElasticsearchProxy(unittest.TestCase):
 
         expected_alias = 'table_search_index'
         result = self.es_proxy.create_document(data=start_data, index=expected_alias)
-        self.assertEquals(expected_alias, result)
+        self.assertEqual(expected_alias, result)
         mock_elasticsearch.bulk.assert_called_with(expected_data)
 
     def test_update_document_with_no_data(self) -> None:
         expected = ''
         result = self.es_proxy.update_document(data=None, index='table_search_index')
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     @patch('uuid.uuid4')
     def test_update_document(self, mock_uuid: MagicMock) -> None:
@@ -628,7 +628,7 @@ class TestElasticsearchProxy(unittest.TestCase):
             }
         ]
         result = self.es_proxy.update_document(data=data, index=expected_alias)
-        self.assertEquals(expected_alias, result)
+        self.assertEqual(expected_alias, result)
         mock_elasticsearch.bulk.assert_called_with(expected_data)
 
     @patch('uuid.uuid4')
@@ -646,7 +646,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         ]
         result = self.es_proxy.delete_document(data=data, index=expected_alias)
 
-        self.assertEquals(expected_alias, result)
+        self.assertEqual(expected_alias, result)
         mock_elasticsearch.bulk.assert_called_with(expected_data)
 
     @patch('uuid.uuid4')
@@ -664,7 +664,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         ]
         result = self.es_proxy.delete_document(data=data, index=expected_alias)
 
-        self.assertEquals(expected_alias, result)
+        self.assertEqual(expected_alias, result)
         mock_elasticsearch.bulk.assert_called_with(expected_data)
 
     def test_get_instance_string(self) -> None:
@@ -712,7 +712,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         resp = self.es_proxy.fetch_dashboard_search_results(query_term='test_query_term',
                                                             page_index=0,
                                                             index='dashboard_search_index')
-        self.assertEquals(resp.total_results, expected.total_results)
+        self.assertEqual(resp.total_results, expected.total_results)
 
         self.assertDictEqual(vars(resp.results[0]),
                              vars(expected.results[0]),

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -239,7 +239,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         resp = self.es_proxy.fetch_table_search_results(query_term='test_query_term')
 
         self.assertEqual(resp.total_results, expected.total_results,
-                          "search result is not of length 1")
+                         "search result is not of length 1")
         self.assertIsInstance(resp.results[0],
                               Table,
                               "Search result received is not of 'Table' type!")
@@ -281,7 +281,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         resp = self.es_proxy.fetch_table_search_results(query_term='test_query_term')
 
         self.assertEqual(resp.total_results, expected.total_results,
-                          "search result is not of length 2")
+                         "search result is not of length 2")
         for i in range(2):
             self.assertIsInstance(resp.results[i],
                                   Table,
@@ -366,14 +366,14 @@ class TestElasticsearchProxy(unittest.TestCase):
                           "AND column_names.raw:(*ds*) " \
                           "AND tags:(test-tag)"
         self.assertEqual(self.es_proxy.parse_filters(filter_list,
-                                                      index=TABLE_INDEX), expected_result)
+                                                     index=TABLE_INDEX), expected_result)
 
     def test_parse_filters_return_no_results(self) -> None:
         filter_list = {
             'unsupported_category': ['fake']
         }
         self.assertEqual(self.es_proxy.parse_filters(filter_list,
-                                                      index=TABLE_INDEX), '')
+                                                     index=TABLE_INDEX), '')
 
     def test_validate_wrong_filters_values(self) -> None:
         search_request = {
@@ -406,7 +406,7 @@ class TestElasticsearchProxy(unittest.TestCase):
                           "column_names:(*test*) OR column_names:(test) OR " \
                           "column_descriptions:(*test*) OR column_descriptions:(test))"
         self.assertEqual(self.es_proxy.parse_query_term(term,
-                                                         index=TABLE_INDEX), expected_result)
+                                                        index=TABLE_INDEX), expected_result)
 
     def test_convert_query_json_to_query_dsl_term_and_filters(self) -> None:
         term = 'test'
@@ -491,7 +491,7 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                        index='user_search_index')
 
         self.assertEqual(resp.total_results, expected.total_results,
-                          "search result is not of length 1")
+                         "search result is not of length 1")
         self.assertIsInstance(resp.results[0],
                               User,
                               "Search result received is not of 'Table' type!")

--- a/tests/unit/test_swagger.py
+++ b/tests/unit/test_swagger.py
@@ -21,12 +21,12 @@ class TestSwagger(unittest.TestCase):
 
     def test_should_get_swagger_docs(self) -> None:
         response = self.app.test_client().get('/apidocs/')
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_should_get_swagger_json(self) -> None:
         response = self.app.test_client().get('/apispec_1.json')
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_should_have_a_component_from_each_reference(self) -> None:
         response = self.app.test_client().get('/apispec_1.json')


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

- Since the `assertEquals` function has been deprecated, replaced it with the `assertEqual` function for all test files.
- `tests/unit/api/dashboard/fixture.py`: Add `chart_names` field to dashboard fixture since model changes in `amundsencommon`
 
### Tests

Passed all existing unit tests

### Documentation

pytest doc about deprecated function: https://docs.python.org/3.3/library/unittest.html#deprecated-aliases
model changes in `amundsencommon`: https://github.com/amundsen-io/amundsencommon/pull/73/files

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

-   [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    -   In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
-   [ ] PR includes a summary of changes.
-   [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
-   [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    -   All the public functions and the classes in the PR contain docstrings that explain what it does
-   [ ] PR passes `make test`
