### PR TITLE
fix: fix table post/put api bug

### DIFF
--- a/search_service/api/document.py
+++ b/search_service/api/document.py
@@ -83,9 +83,7 @@ class BaseDocumentsAPI(Resource):
         args = self.parser.parse_args()
 
         try:
-            table_dict_list = []
-            for table_str in args.get('data'):
-                table_dict_list.append(literal_eval(table_str))
+            table_dict_list = [literal_eval(table_str) for table_str in args.get('data')]
             table_list_json = json.dumps(table_dict_list)
             data = self.schema(many=True, strict=False).loads(table_list_json).data
             results = self.proxy.update_document(data=data, index=args.get('index'))

--- a/search_service/api/document.py
+++ b/search_service/api/document.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import json
 
 from http import HTTPStatus
 from typing import Tuple, Any
-
+from ast import literal_eval
 from flasgger import swag_from
 from flask_restful import Resource, reqparse
 from search_service.proxy import get_proxy_client
@@ -58,7 +59,7 @@ class BaseDocumentsAPI(Resource):
          :param data: list of data objects to be indexed in Elasticsearch
          :return: name of new index
          """
-        self.parser.add_argument('data', required=True)
+        self.parser.add_argument('data', required=True, action='append')
         args = self.parser.parse_args()
 
         try:
@@ -78,11 +79,15 @@ class BaseDocumentsAPI(Resource):
         :param data: list of data objects to be indexed in Elasticsearch
         :return: name of index
         """
-        self.parser.add_argument('data', required=True)
+        self.parser.add_argument('data', required=True, action='append')
         args = self.parser.parse_args()
 
         try:
-            data = self.schema(many=True, strict=False).loads(args.get('data')).data
+            table_dict_list = []
+            for table_str in args.get('data'):
+                table_dict_list.append(literal_eval(table_str))
+            table_list_json = json.dumps(table_dict_list)
+            data = self.schema(many=True, strict=False).loads(table_list_json).data
             results = self.proxy.update_document(data=data, index=args.get('index'))
             return results, HTTPStatus.OK
         except RuntimeError as e:

--- a/search_service/api/swagger_doc/document/table_post.yml
+++ b/search_service/api/swagger_doc/document/table_post.yml
@@ -11,19 +11,18 @@ parameters:
       type: string
       default: 'table_search_index'
     required: false
-  - name: body
-    in: body
-    schema:
-      type: object
-      name: data
-      properties:
-        data:
-          type: array
-          description: 'List of tables'
-          items:
-            $ref: '#/components/schemas/TableFields'
-    description: 'Tables to create'
-    required: true
+requestBody:
+  content:
+    'application/json':
+      schema:
+        type: object
+        properties:
+          data:
+            type: array
+            items:
+              $ref: '#/components/schemas/TableFields'
+  description: 'Tables to create'
+  required: true
 responses:
   200:
     description: Empty json response

--- a/search_service/api/swagger_doc/document/table_put.yml
+++ b/search_service/api/swagger_doc/document/table_put.yml
@@ -11,19 +11,18 @@ parameters:
       type: string
       default: 'table_search_index'
     required: false
-  - name: body
-    in: body
-    schema:
-      type: object
-      name: data
-      properties:
-        data:
-          type: array
-          description: 'List of tables'
-          items:
-            $ref: '#/components/schemas/TableFields'
-    description: 'Tables to update'
-    required: true
+requestBody:
+  content:
+    'application/json':
+      schema:
+        type: object
+        properties:
+          data:
+            type: array
+            items:
+              $ref: '#/components/schemas/TableFields'
+  description: 'Tables to update'
+  required: true
 responses:
   200:
     description: Empty json response

--- a/search_service/api/swagger_doc/document/user_post.yml
+++ b/search_service/api/swagger_doc/document/user_post.yml
@@ -11,19 +11,18 @@ parameters:
       type: string
       default: user_search_index
     required: false
-  - name: body
-    in: body
-    schema:
-      type: object
-      name: data
-      properties:
-        data:
-          type: array
-          description: 'List of users'
-          items:
-            $ref: '#/components/schemas/UserFields'
-    description: 'Users to create'
-    required: true
+requestBody:
+  content:
+    'application/json':
+      schema:
+        type: object
+        properties:
+          data:
+            type: array
+            items:
+              $ref: '#/components/schemas/UserFields'
+  description: 'Users to create'
+  required: true
 responses:
   200:
     description: Empty json response

--- a/search_service/api/swagger_doc/document/user_put.yml
+++ b/search_service/api/swagger_doc/document/user_put.yml
@@ -11,19 +11,18 @@ parameters:
       type: string
       default: user_search_index
     required: false
-  - name: body
-    in: body
-    schema:
-      type: object
-      name: data
-      properties:
-        data:
-          type: array
-          description: 'List of users'
-          items:
-            $ref: '#/components/schemas/UserFields'
-    description: 'Users to update'
-    required: true
+requestBody:
+  content:
+    'application/json':
+      schema:
+        type: object
+        properties:
+          data:
+            type: array
+            items:
+              $ref: '#/components/schemas/UserFields'
+  description: 'Users to update'
+  required: true
 responses:
   200:
     description: Empty json response

--- a/search_service/api/swagger_doc/template.yml
+++ b/search_service/api/swagger_doc/template.yml
@@ -52,6 +52,10 @@ components:
     TableFields:
       type: object
       properties:
+        id:
+          type: string
+          description: 'elasticsearch doc id'
+          example: 'M81jD3cBdULZTSY96PSh'
         name:
           type: string
           description: 'name of table'
@@ -82,16 +86,54 @@ components:
               type: string
           description: 'list of column names'
           example: ['col1', 'col2']
+        column_descriptions:
+          type: array
+          items:
+            type: string
+          description: 'list of column descriptions'
+          example: ['column description1', 'column description2']
+        programmatic_descriptions:
+          type: array
+          items:
+            type: string
+          description: 'list of programmatic descriptions'
+          example: ['programmatic description1', 'programmatic description2']
         tags:
           type: array
           items:
-              type: string
+            type: object
+            properties:
+              tag_name:
+                type: string
           description: 'list of table tags'
-          example: ['tag2', 'tag1']
+          example: [{'tag_name': 'tag1'}, {'tag_name': 'tag2'}]
+        badges:
+          type: array
+          items:
+            type: object
+            properties:
+              tag_name:
+                type: string
+          description: 'list of table badges'
+          example: [{'tag_name': 'badge1'}, {'tag_name': 'badge2'}]
         last_updated_timestamp:
           type: integer
           description: 'table last updated time'
           example: 1568814420
+        display_name:
+          type: string
+          description: 'table display name'
+          example: 'display_name'
+        total_usage:
+          type: int
+          description: 'total usage'
+          example: 0
+        schema_description:
+          type: array
+          items:
+            type: string
+          description: 'list of schema descriptions'
+          example: ['schema description1', 'schema description2']
     DashboardFields:
       type: object
       properties:
@@ -130,6 +172,10 @@ components:
     UserFields:
       type: object
       properties:
+        id:
+          type: string
+          description: 'elasticsearch doc id'
+          example: 'M81jD3cBdULZTSY96PSh'
         name:
           type: string
           description: 'user name'

--- a/search_service/models/table.py
+++ b/search_service/models/table.py
@@ -17,20 +17,20 @@ class Table(Base):
     This represents the part of a table stored in the search proxy
     """
     id: str
-    database: Optional[str] = None
-    cluster: Optional[str] = None
-    schema: Optional[str] = None
-    name: Optional[str] = None
-    key: Optional[str] = None
+    database: str
+    cluster: str
+    schema: str
+    name: str
+    key: str
     display_name: Optional[str] = None
-    tags: List[Tag] = []
-    badges: List[Tag] = []
+    tags: Optional[List[Tag]] = None
+    badges: Optional[List[Tag]] = None
     description: Optional[str] = None
     last_updated_timestamp: int = int(time.time())
     # The following properties are lightly-transformed properties from the normal table object:
-    column_names: List[str] = []
-    column_descriptions: List[str] = []
-    programmatic_descriptions: List[str] = []
+    column_names: Optional[List[str]] = None
+    column_descriptions: Optional[List[str]] = None
+    programmatic_descriptions: Optional[List[str]] = None
     # The following are search-only properties:
     total_usage: int = 0
     schema_description: Optional[str] = attr.ib(default=None)
@@ -40,8 +40,14 @@ class Table(Base):
 
     def get_attrs_dict(self) -> dict:
         attrs_dict = self.__dict__.copy()
-        attrs_dict['tags'] = [str(tag) for tag in self.tags]
-        attrs_dict['badges'] = [str(tag) for tag in self.badges]
+        if self.tags is not None:
+            attrs_dict['tags'] = [str(tag) for tag in self.tags]
+        else:
+            attrs_dict['tags'] = None
+        if self.badges is not None:
+            attrs_dict['badges'] = [str(badge) for badge in self.badges]
+        else:
+            attrs_dict['badges'] = None
         return attrs_dict
 
     @classmethod

--- a/search_service/models/table.py
+++ b/search_service/models/table.py
@@ -8,6 +8,7 @@ from marshmallow_annotations.ext.attrs import AttrsSchema
 
 from .base import Base
 from search_service.models.tag import Tag
+import time
 
 
 @attr.s(auto_attribs=True, kw_only=True)
@@ -15,18 +16,19 @@ class Table(Base):
     """
     This represents the part of a table stored in the search proxy
     """
-    database: str
-    cluster: str
-    schema: str
-    name: str
-    key: str
+    id: str
+    database: Optional[str] = None
+    cluster: Optional[str] = None
+    schema: Optional[str] = None
+    name: Optional[str] = None
+    key: Optional[str] = None
     display_name: Optional[str] = None
-    tags: List[Tag]
-    badges: List[Tag]
+    tags: List[Tag] = []
+    badges: List[Tag] = []
     description: Optional[str] = None
-    last_updated_timestamp: int
+    last_updated_timestamp: int = int(time.time())
     # The following properties are lightly-transformed properties from the normal table object:
-    column_names: List[str]
+    column_names: List[str] = []
     column_descriptions: List[str] = []
     programmatic_descriptions: List[str] = []
     # The following are search-only properties:
@@ -34,12 +36,18 @@ class Table(Base):
     schema_description: Optional[str] = attr.ib(default=None)
 
     def get_id(self) -> str:
-        # uses the table key as the document id in ES
-        return self.key
+        return self.id
+
+    def get_attrs_dict(self) -> dict:
+        attrs_dict = self.__dict__.copy()
+        attrs_dict['tags'] = [str(tag) for tag in self.tags]
+        attrs_dict['badges'] = [str(tag) for tag in self.badges]
+        return attrs_dict
 
     @classmethod
     def get_attrs(cls) -> Set:
         return {
+            'id',
             'name',
             'key',
             'description',

--- a/search_service/models/tag.py
+++ b/search_service/models/tag.py
@@ -13,6 +13,9 @@ class Tag:
     def __init__(self, tag_name: str):
         self.tag_name = tag_name
 
+    def __str__(self):
+        return self.tag_name
+
 
 class TagSchema(AttrsSchema):
     class Meta:

--- a/search_service/models/tag.py
+++ b/search_service/models/tag.py
@@ -13,7 +13,7 @@ class Tag:
     def __init__(self, tag_name: str):
         self.tag_name = tag_name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.tag_name
 
 

--- a/search_service/models/user.py
+++ b/search_service/models/user.py
@@ -17,14 +17,16 @@ class User(Base, CommonUser):
     This represents the part of a user stored in the search proxy
     """
     manager_email: Optional[str] = None
+    id: str
 
     def get_id(self) -> str:
         # uses the user email as the document id in ES
-        return self.email if self.email else ''
+        return self.id
 
     @classmethod
     def get_attrs(cls) -> Set:
         return {
+            'id',
             'full_name',
             'first_name',
             'last_name',

--- a/search_service/proxy/atlas.py
+++ b/search_service/proxy/atlas.py
@@ -92,7 +92,8 @@ class AtlasProxy(BaseProxy):
 
             badges: List[Tag] = tags
 
-            table = Table(name=entity_name,
+            table = Table(id=f"{entity.typeName}://{db_cluster}.{db_name}/{entity_name}",
+                          name=entity_name,
                           key=f"{entity.typeName}://{db_cluster}.{db_name}/{entity_name}",
                           description=entity_attrs.get('description'),
                           cluster=db_cluster,

--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -116,6 +116,8 @@ class ElasticsearchProxy(BaseProxy):
 
         for hit in response:
             try:
+                es_metadata = hit.__dict__.get('meta', {})
+
                 # ES hit: {'_d_': {'key': xxx...}
                 es_payload = hit.__dict__.get('_d_', {})
                 if not es_payload:
@@ -124,6 +126,7 @@ class ElasticsearchProxy(BaseProxy):
                 for attr, val in es_payload.items():
                     if attr in model.get_attrs():
                         result[attr] = self._get_instance(attr=attr, val=val)
+                result['id'] = self._get_instance(attr='id', val=es_metadata['id'])
 
                 results.append(model(**result))
             except Exception:
@@ -590,7 +593,7 @@ class ElasticsearchProxy(BaseProxy):
 
         for item in data:
             actions.append({'update': {'_index': index_key, '_type': item.get_type(), '_id': item.get_id()}})
-            actions.append({'doc': item.__dict__})
+            actions.append({'doc': item.get_attrs_dict()})
         return actions
 
     def _build_delete_actions(self, data: List[str], index_key: str, type: str) -> List[Dict[str, Any]]:

--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -117,8 +117,33 @@ class ElasticsearchProxy(BaseProxy):
         for hit in response:
             try:
                 es_metadata = hit.__dict__.get('meta', {})
-
-                # ES hit: {'_d_': {'key': xxx...}
+                """
+                ES hit example:
+                {
+                    '_d_': {
+                        'name': 'name',
+                        'database': 'database',
+                        'schema': 'schema',
+                        'key': 'database://cluster.schema/name',
+                        'cluster': 'cluster',
+                        'column_descriptions': ['description1', 'description2'],
+                        'column_names': ['colname1', 'colname2'],
+                        'description': None,
+                        'display_name': 'display name',
+                        'last_updated_timestamp': 12345678,
+                        'programmatic_descriptions': [],
+                        'schema_description': None,
+                        'tags': ['tag1', 'tag2'],
+                        'badges': [],
+                        'total_usage': 0
+                    },
+                    'mata': {
+                        'index': 'table index',
+                        'id': 'table id',
+                        'type': 'type'
+                    }
+                }
+                """
                 es_payload = hit.__dict__.get('_d_', {})
                 if not es_payload:
                     raise Exception('The ES doc not contain required field')

--- a/tests/unit/api/document/test_document_tables_api.py
+++ b/tests/unit/api/document/test_document_tables_api.py
@@ -8,7 +8,9 @@ from mock import patch, Mock, MagicMock
 
 from search_service.api.document import DocumentTablesAPI
 from search_service import create_app
-
+from search_service.models.table import Table
+from search_service.models.tag import Tag
+import json
 
 class TestDocumentTablesAPI(unittest.TestCase):
     def setUp(self) -> None:
@@ -38,6 +40,45 @@ class TestDocumentTablesAPI(unittest.TestCase):
         response = DocumentTablesAPI().put()
         self.assertEqual(list(response)[1], HTTPStatus.OK)
         mock_proxy.update_document.assert_called_with(data=[], index='fake_index')
+
+    @patch('search_service.api.document.reqparse.RequestParser')
+    @patch('search_service.api.document.get_proxy_client')
+    def test_put_multiple_tables(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
+        mock_proxy = get_proxy.return_value = Mock()
+        input_data = [
+            json.dumps({
+                'id': 'table1',
+                'key': 'table1',
+                'cluster': 'cluster1',
+                'database': 'database1',
+                'name': 'name1',
+                'schema': 'schema1',
+                'last_updated_timestamp': 12345678,
+                'tags': [{'tag_name': 'tag1'}, {'tag_name': 'tag2'}]
+            }),
+            json.dumps({
+                'id': 'table2',
+                'key': 'table2',
+                'cluster': 'cluster2',
+                'database': 'database2',
+                'name': 'name2',
+                'schema': 'schema2',
+                'last_updated_timestamp': 12345678,
+                'tags': [{'tag_name': 'tag3'}, {'tag_name': 'tag4'}]
+            })
+        ]
+        RequestParser().parse_args.return_value = dict(data=input_data, index='fake_index')
+
+        expected_data = [Table(id='table1', database='database1', cluster='cluster1', schema='schema1', name='name1',
+                               key='table1', tags=[Tag(tag_name='tag1'), Tag(tag_name='tag2')],
+                               last_updated_timestamp=12345678),
+                         Table(id='table2', database='database2', cluster='cluster2', schema='schema2', name='name2',
+                               key='table2', tags=[Tag(tag_name='tag3'), Tag(tag_name='tag4')],
+                               last_updated_timestamp=12345678)]
+
+        response = DocumentTablesAPI().put()
+        self.assertEqual(list(response)[1], HTTPStatus.OK)
+        mock_proxy.update_document.assert_called_with(data=expected_data, index='fake_index')
 
     def test_should_not_reach_create_with_id(self) -> None:
         response = self.app.test_client().post('/document_table/1')

--- a/tests/unit/api/document/test_document_tables_api.py
+++ b/tests/unit/api/document/test_document_tables_api.py
@@ -33,7 +33,7 @@ class TestDocumentTablesAPI(unittest.TestCase):
     @patch('search_service.api.document.get_proxy_client')
     def test_put(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
-        RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
+        RequestParser().parse_args.return_value = dict(data=[], index='fake_index')
 
         response = DocumentTablesAPI().put()
         self.assertEqual(list(response)[1], HTTPStatus.OK)

--- a/tests/unit/api/document/test_document_tables_api.py
+++ b/tests/unit/api/document/test_document_tables_api.py
@@ -12,6 +12,7 @@ from search_service.models.table import Table
 from search_service.models.tag import Tag
 import json
 
+
 class TestDocumentTablesAPI(unittest.TestCase):
     def setUp(self) -> None:
         self.app = create_app(config_module_class='search_service.config.Config')

--- a/tests/unit/api/document/test_document_users_api.py
+++ b/tests/unit/api/document/test_document_users_api.py
@@ -33,7 +33,7 @@ class TestDocumentUsersAPI(unittest.TestCase):
     @patch('search_service.api.document.get_proxy_client')
     def test_put(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
-        RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
+        RequestParser().parse_args.return_value = dict(data=[], index='fake_index')
 
         response = DocumentUsersAPI().put()
         self.assertEqual(list(response)[1], HTTPStatus.OK)

--- a/tests/unit/api/table/fixtures.py
+++ b/tests/unit/api/table/fixtures.py
@@ -6,7 +6,8 @@ from search_service.models.tag import Tag
 
 
 def mock_proxy_results() -> Table:
-    return Table(name='hello',
+    return Table(id='world',
+                 name='hello',
                  key='world',
                  description='des1',
                  cluster='clust',
@@ -22,7 +23,8 @@ def mock_proxy_results() -> Table:
 
 
 def mock_default_proxy_results() -> Table:
-    return Table(name='',
+    return Table(id='',
+                 name='',
                  key='',
                  description='',
                  cluster='',
@@ -39,6 +41,7 @@ def mock_default_proxy_results() -> Table:
 
 def mock_json_response() -> dict:
     return {
+        "id": "world",
         "name": "hello",
         "key": "world",
         "description": "des1",
@@ -59,6 +62,7 @@ def mock_json_response() -> dict:
 
 def default_json_response() -> dict:
     return {
+        "id": '',
         "name": '',
         "key": '',
         "description": '',

--- a/tests/unit/api/table/fixtures.py
+++ b/tests/unit/api/table/fixtures.py
@@ -56,7 +56,7 @@ def mock_json_response() -> dict:
         "schema_description": 'schema description',
         'programmatic_descriptions': [],
         'total_usage': 0,
-        'column_descriptions': []
+        'column_descriptions': None
     }
 
 
@@ -77,5 +77,5 @@ def default_json_response() -> dict:
         "schema_description": '',
         'programmatic_descriptions': [],
         'total_usage': 0,
-        'column_descriptions': []
+        'column_descriptions': None
     }

--- a/tests/unit/proxy/test_atlas.py
+++ b/tests/unit/proxy/test_atlas.py
@@ -221,7 +221,10 @@ class TestAtlasProxy(unittest.TestCase):
 
     def test_search_normal(self) -> None:
         expected = SearchTableResult(total_results=2,
-                                     results=[Table(name=self.entity1_name,
+                                     results=[Table(id=f"{self.entity_type}://"
+                                                       f"{self.cluster}.{self.db}/"
+                                                       f"{self.entity1_name}",
+                                                    name=self.entity1_name,
                                                     key=f"{self.entity_type}://"
                                                         f"{self.cluster}.{self.db}/"
                                                         f"{self.entity1_name}",

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -30,7 +30,7 @@ class MockSearchResult:
                  tags: Iterable[Tag],
                  badges: Iterable[Tag],
                  last_updated_timestamp: int,
-                 programmatic_descriptions: List[str] = []) -> None:
+                 programmatic_descriptions: List[str] = None) -> None:
         self.name = name
         self.key = key
         self.description = description
@@ -250,7 +250,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                column_names=['test_col1', 'test_col2'],
                                                tags=[],
                                                badges=self.mock_empty_badge,
-                                               last_updated_timestamp=1527283287)])
+                                               last_updated_timestamp=1527283287,
+                                               programmatic_descriptions=[])])
 
         resp = self.es_proxy.fetch_table_search_results(query_term='test_query_term')
 
@@ -283,7 +284,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                column_names=['test_col1', 'test_col2'],
                                                tags=[],
                                                badges=self.mock_empty_badge,
-                                               last_updated_timestamp=1527283287),
+                                               last_updated_timestamp=1527283287,
+                                               programmatic_descriptions=[]),
                                          Table(id='test_key2',
                                                name='test_table2',
                                                key='test_key2',
@@ -326,7 +328,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                column_names=['test_col1', 'test_col2'],
                                                tags=self.mock_empty_tag,
                                                badges=self.mock_empty_badge,
-                                               last_updated_timestamp=1527283287)])
+                                               last_updated_timestamp=1527283287,
+                                               programmatic_descriptions=[])])
         search_request = {
             'type': 'AND',
             'filters': {
@@ -564,7 +567,7 @@ class TestElasticsearchProxy(unittest.TestCase):
                 'tags': [],
                 'badges': [],
                 'total_usage': 0,
-                'programmatic_descriptions': [],
+                'programmatic_descriptions': None,
                 'schema_description': 'schema description 1',
             },
             {
@@ -578,7 +581,7 @@ class TestElasticsearchProxy(unittest.TestCase):
                 'id': 'snowflake://blue.test_schema/bitcoin_wallets',
                 'cluster': 'blue',
                 'column_names': ['5', '6'],
-                'column_descriptions': [],
+                'column_descriptions': None,
                 'database': 'snowflake',
                 'schema': 'test_schema',
                 'description': 'A table for lots of things!',
@@ -644,7 +647,7 @@ class TestElasticsearchProxy(unittest.TestCase):
                     'tags': [],
                     'badges': [],
                     'total_usage': 0,
-                    'programmatic_descriptions': [],
+                    'programmatic_descriptions': None,
                     'schema_description': 'schema description 1',
                 }
             }


### PR DESCRIPTION
Signed-off-by: tianru zhou <tianru.zhou@databricks.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

fix table post/put api bugs

- old api definition contains openapi 2 syntax(put `request body` within `parameters` part), which causes weird exception: components within `template.yml` can't be found.

- `data` within request body for table/user put/post should be a list, current parser syntax doesn't work correctly for lists.

Related FE PR: https://github.com/amundsen-io/amundsenfrontendlibrary/pull/883

### Tests

- pass all unit tests locally
- manual end-to-end test for table put/post api

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

-   [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    -   In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
-   [ ] PR includes a summary of changes.
-   [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
-   [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    -   All the public functions and the classes in the PR contain docstrings that explain what it does
-   [ ] PR passes `make test`
