### PR TITLE
fix: fix some problems with table mutation APIs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ flask-cors==3.0.8
 isort[colors]~=5.7
 itsdangerous==0.24
 Jinja2>=2.10.1
-jsonschema==2.6.0
+jsonschema>=3.0.1,<4.0
 marshmallow>=2.15.3,<3.0
 marshmallow-annotations>=2.4.0,<3.0
 mock==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ elasticsearch==6.2.0
 elasticsearch-dsl==6.1.0
 flake8==3.5.0
 flake8-tidy-imports==1.1.0
-flasgger==0.9.3
+flasgger==0.9.5
 Flask==1.0.2
 Flask-RESTful==0.3.6
 flask-cors==3.0.8

--- a/search_service/api/swagger_doc/template.yml
+++ b/search_service/api/swagger_doc/template.yml
@@ -129,11 +129,9 @@ components:
           description: 'total usage'
           example: 0
         schema_description:
-          type: array
-          items:
-            type: string
-          description: 'list of schema descriptions'
-          example: ['schema description1', 'schema description2']
+          type: string
+          description: 'schema description'
+          example: 'schema description1'
     DashboardFields:
       type: object
       properties:

--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -611,7 +611,7 @@ class ElasticsearchProxy(BaseProxy):
         for item in data:
             index_action = {'index': {'_index': index_key, '_type': item.get_type(), '_id': item.get_id()}}
             actions.append(index_action)
-            actions.append(item.__dict__)
+            actions.append(item.get_attrs_dict())
         return actions
 
     def _build_update_actions(self, data: List[Table], index_key: str) -> List[Dict[str, Any]]:

--- a/tests/unit/api/document/test_document_tables_api.py
+++ b/tests/unit/api/document/test_document_tables_api.py
@@ -28,7 +28,7 @@ class TestDocumentTablesAPI(unittest.TestCase):
     @patch('search_service.api.document.get_proxy_client')
     def test_post(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
-        RequestParser().parse_args.return_value = dict(data='[]', index='fake_index')
+        RequestParser().parse_args.return_value = dict(data=[], index='fake_index')
 
         response = DocumentTablesAPI().post()
         self.assertEqual(list(response)[1], HTTPStatus.OK)

--- a/tests/unit/api/document/test_document_user_api.py
+++ b/tests/unit/api/document/test_document_user_api.py
@@ -25,7 +25,7 @@ class TestDocumentUserAPI(unittest.TestCase):
     @patch('search_service.api.document.get_proxy_client')
     def test_delete(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
-        RequestParser().parse_args.return_value = dict(data='[]', index='fake_index')
+        RequestParser().parse_args.return_value = dict(data=[], index='fake_index')
 
         response = DocumentUserAPI().delete(document_id='fake id')
         self.assertEqual(list(response)[1], HTTPStatus.OK)

--- a/tests/unit/api/document/test_document_users_api.py
+++ b/tests/unit/api/document/test_document_users_api.py
@@ -25,7 +25,7 @@ class TestDocumentUsersAPI(unittest.TestCase):
     @patch('search_service.api.document.get_proxy_client')
     def test_post(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
-        RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
+        RequestParser().parse_args.return_value = dict(data={}, index='fake_index')
 
         response = DocumentUsersAPI().post()
         self.assertEqual(list(response)[1], HTTPStatus.OK)


### PR DESCRIPTION
Closes https://github.com/amundsen-io/amundsen/issues/176

### Summary of Changes

I started digging into that bug, and found a chain of problems:

* `flasgger` was outdated, causing the generated sample query to be wrong
* Inside `BaseDocumentsAPI`, there were some code typos and bad error handling
* The `TableField` swagger document wasn't aligned with the `Table` model
* The elasticsearch proxy was using a shallow serialization method in this code path, not the deep serialize

### Tests

The affected tests were passing in stringified content, but other ones were actual objects. I've made them all pass in native objects, which I believe is correct unless I'm missing something.

We're clearly not testing in a way that actually exercises this code realistically (actually calling ES proxy). But given that this bug was broken on multiple levels, I'm not sure that people are actually using these APIs. So while it's not ideal, I don't think it's super high priority to add tests to these endpoints. (there's a stronger argument to say that we should just remove these endpoints entirely, but I think they're useful so I don't think that's necessary)

### Documentation

n/a

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

-   [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    -   In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
-   [ ] PR includes a summary of changes.
-   [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
-   [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    -   All the public functions and the classes in the PR contain docstrings that explain what it does
-   [ ] PR passes `make test`
